### PR TITLE
Add autoregressive pretraining workflow

### DIFF
--- a/.github/workflows/pretrain.yml
+++ b/.github/workflows/pretrain.yml
@@ -1,0 +1,14 @@
+name: Pretrain Smoke Test
+on: [push, pull_request]
+jobs:
+  pretrain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install torch pandas scikit-learn
+      - name: Run AR pretrain smoke test
+        run: python scripts/ar_pretrain.py --epochs 1 --batch_size 2 --synthetic

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # transaction_transformer
 A transformer that predicts the next transaction for a user
+
+## Self-supervised Pre-training
+
+The project supports an auto-regressive pre-training stage. Run
+
+```bash
+python scripts/ar_pretrain.py --epochs 20 --batch_size 512 --lr 1e-4
+```
+
+to train the backbone in a self-supervised manner. Afterwards fine-tune the
+fraud classifier using `main.py`, which automatically loads
+`pretrained_backbone.pt` when present. Hyperparameters should remain the same
+between the two steps.

--- a/scripts/ar_pretrain.py
+++ b/scripts/ar_pretrain.py
@@ -1,0 +1,165 @@
+import os
+import argparse
+from datetime import datetime
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from txn_model.data.dataset import TxnDataset, collate_fn
+from txn_model.config import (ModelConfig, FieldTransformerConfig,
+                              SequenceTransformerConfig, LSTMConfig)
+from txn_model.model import TransactionModel
+from txn_model.data.preprocessing import preprocess
+
+
+def slice_batch(batch):
+    cat = batch["cat"]
+    cont = batch["cont"]
+    pad = batch["pad_mask"]
+    inp_cat = cat[:, :-1, :]
+    inp_cont = cont[:, :-1, :]
+    tgt_cat = cat[:, -1, :]
+    tgt_cont = cont[:, -1, :]
+    inp_mask = pad[:, :-1]
+    return inp_cat, inp_cont, inp_mask, tgt_cat, tgt_cont
+
+
+def build_config(cat_vocab_sizes, cont_features):
+    EMB_DIM = 48
+    ROW_DIM = 256
+    HEADS_F = 4
+    HEADS_S = 4
+    DEPTH_F = 1
+    DEPTH_S = 4
+    FFN_MULT = 2
+    DROPOUT = 0.10
+    LN_EPS = 1e-6
+    LSTM_HID = ROW_DIM
+    LSTM_LAYERS = 2
+    NUM_CLASSES = 2
+
+    field_cfg = FieldTransformerConfig(
+        d_model=EMB_DIM, n_heads=HEADS_F, depth=DEPTH_F,
+        ffn_mult=FFN_MULT, dropout=DROPOUT,
+        layer_norm_eps=LN_EPS, norm_first=True
+    )
+    seq_cfg = SequenceTransformerConfig(
+        d_model=ROW_DIM, n_heads=HEADS_S, depth=DEPTH_S,
+        ffn_mult=FFN_MULT, dropout=DROPOUT,
+        layer_norm_eps=LN_EPS, norm_first=True
+    )
+    lstm_cfg = LSTMConfig(
+        hidden_size=LSTM_HID, num_layers=LSTM_LAYERS,
+        num_classes=NUM_CLASSES, dropout=DROPOUT
+    )
+
+    return ModelConfig(
+        cat_vocab_sizes=cat_vocab_sizes,
+        cont_features=cont_features,
+        emb_dim=EMB_DIM,
+        dropout=DROPOUT,
+        padding_idx=0,
+        field_transformer=field_cfg,
+        sequence_transformer=seq_cfg,
+        lstm_config=lstm_cfg,
+        total_epochs=0,
+    )
+
+
+def generate_synthetic():
+    import pandas as pd
+    import numpy as np
+    rows = 40
+    df = pd.DataFrame({
+        "User": np.repeat(np.arange(4), 10),
+        "Card": np.random.randint(0, 3, rows),
+        "Use Chip": np.random.randint(0, 2, rows),
+        "Merchant Name": np.random.randint(0, 4, rows),
+        "Merchant City": np.random.randint(0, 3, rows),
+        "Merchant State": np.random.randint(0, 3, rows),
+        "Zip": np.random.randint(0, 5, rows),
+        "MCC": np.random.randint(0, 3, rows),
+        "Errors?": np.random.randint(0, 2, rows),
+        "Year": np.random.randint(0, 2, rows),
+        "Month": np.random.randint(0, 12, rows),
+        "Day": np.random.randint(0, 28, rows),
+        "Hour": np.random.randint(0, 24, rows),
+        "Amount": np.random.randn(rows),
+        "is_fraud": np.random.randint(0, 2, rows),
+    })
+    cat_feats = [
+        "User", "Card", "Use Chip", "Merchant Name", "Merchant City",
+        "Merchant State", "Zip", "MCC", "Errors?", "Year", "Month",
+        "Day", "Hour",
+    ]
+    cont_feats = ["Amount"]
+    encoders = {c: {"inv": [0, 1, 2, 3, 4]} for c in cat_feats}
+    return df, encoders, cat_feats, cont_feats
+
+
+def main(args):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    if args.synthetic:
+        train_df, encoders, cat_feats, cont_feats = generate_synthetic()
+    else:
+        if not os.path.exists(args.cache):
+            raise FileNotFoundError(args.cache)
+        (train_df, _, _, encoders,
+         cat_feats, cont_feats, _) = torch.load(args.cache, weights_only=False)
+
+    cat_sizes = {c: len(encoders[c]["inv"]) for c in cat_feats}
+    config = build_config(cat_sizes, cont_feats)
+    model = TransactionModel(config).to(device)
+
+    ds = TxnDataset(
+        df=train_df,
+        group_by=cat_feats[0],
+        cat_features=cat_feats,
+        cont_features=cont_feats,
+        window_size=args.window,
+        stride=args.window,
+    )
+    loader = DataLoader(ds, batch_size=args.batch_size, shuffle=True,
+                        collate_fn=collate_fn)
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    crit_cat = nn.CrossEntropyLoss()
+    crit_cont = nn.MSELoss()
+
+    model.train()
+    sizes = [cat_sizes[c] for c in cat_feats]
+    for ep in range(args.epochs):
+        for batch in loader:
+            inp_cat, inp_cont, inp_mask, tgt_cat, tgt_cont = slice_batch(batch)
+            inp_cat = inp_cat.to(device)
+            inp_cont = inp_cont.to(device)
+            inp_mask = inp_mask.to(device)
+            tgt_cat = tgt_cat.to(device)
+            tgt_cont = tgt_cont.to(device)
+            logits_cat, pred_cont = model(inp_cat, inp_cont, inp_mask.bool(), mode="ar")
+            start = 0
+            loss_cat = 0.0
+            for i, V in enumerate(sizes):
+                end = start + V
+                loss_cat += crit_cat(logits_cat[:, start:end], tgt_cat[:, i])
+                start = end
+            loss = loss_cat + crit_cont(pred_cont, tgt_cont)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        torch.save(model.state_dict(), "pretrained_backbone.pt")
+        print(f"{datetime.now()} Epoch {ep+1}/{args.epochs} loss {loss.item():.4f}")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--cache", default="processed_data.pt")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch_size", type=int, default=16)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--window", type=int, default=10)
+    p.add_argument("--synthetic", action="store_true")
+    args = p.parse_args()
+    main(args)


### PR DESCRIPTION
## Summary
- implement autoregressive pretraining script
- extend `TransactionModel` with AR heads and mode switch
- load pretrained weights in training loop
- add minimal smoke test helper and CI workflow
- document pretraining usage

## Testing
- `python scripts/ar_pretrain.py --epochs 1 --batch_size 2 --synthetic` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686f0a50d820832f99cb1bfe1d37cc6d