### PR TITLE
Add verbose logging across modules

### DIFF
--- a/src/txn_model/evaluate.py
+++ b/src/txn_model/evaluate.py
@@ -15,12 +15,15 @@ def evaluate_binary(
 ) -> tuple[float, float]:
     """Run a full pass over ``loader`` and compute loss + accuracy."""
     model.eval()
+    print("[Evaluate] Model set to eval mode")
     total_loss = 0.0
     total_correct = 0
     total_samples = 0
 
     with torch.no_grad():
         for batch_idx, batch in enumerate(loader, 1):
+            logger.debug("Processing eval batch %d", batch_idx)
+            print(f"[Evaluate] Batch {batch_idx}/{len(loader)}")
             inp_cat = batch["cat"][:, :-1].to(device)
             inp_cont = batch["cont"][:, :-1].to(device)
             pad_mask = batch["pad_mask"][:, :-1].to(device).bool()
@@ -45,9 +48,12 @@ def evaluate_binary(
             logger.debug(
                 "Eval batch %d/%d | loss %.4f", batch_idx, len(loader), loss.item()
             )
+            print(f"[Evaluate] loss={loss.item():.4f}")
 
     avg_loss = total_loss / total_samples
     accuracy = total_correct / total_samples
+
+    print(f"[Evaluate] Avg loss {avg_loss:.4f}, accuracy {accuracy:.2%}")
 
     model.train()
     return avg_loss, accuracy

--- a/src/txn_model/main.py
+++ b/src/txn_model/main.py
@@ -28,33 +28,42 @@ def main() -> None:
         t0 = time.perf_counter()
         train_df, val_df, test_df, encoders, cat_features_loaded, cont_features_loaded, scaler = torch.load(PD_CACHE, weights_only=False)
         logger.info("Loaded processed data (%.2fs)", time.perf_counter() - t0)
+        print(f"[Main] Loaded cached processed data in {time.perf_counter() - t0:.2f}s")
     else:
         logger.info("Running full preprocess pipeline")
+        print("[Main] Running full preprocess pipeline")
         t0 = time.perf_counter()
         train_df, val_df, test_df, encoders, cat_features_loaded, cont_features_loaded, scaler = preprocess(
             DATASET_PATH, cat_features, cont_features
         )
         logger.info("Preprocess completed in %.2fs", time.perf_counter() - t0)
+        print(f"[Main] Preprocess completed in {time.perf_counter() - t0:.2f}s")
         torch.save((train_df, val_df, test_df, encoders, cat_features_loaded, cont_features_loaded, scaler), PD_CACHE)
         logger.info("Saved processed data to %s", PD_CACHE)
+        print(f"[Main] Saved processed data to {PD_CACHE}")
 
     cat_vocab_sizes = {col: len(enc["inv"]) for col, enc in encoders.items()}
 
     logger.info("Building TxnDataset objects")
+    print("[Main] Building TxnDataset objects")
     t_ds = time.perf_counter()
     train_ds = TxnDataset(train_df, group_by="User", cat_features=cat_features_loaded, cont_features=cont_features_loaded, window_size=100, stride=50)
     val_ds = TxnDataset(val_df, group_by="User", cat_features=cat_features_loaded, cont_features=cont_features_loaded, window_size=100, stride=50)
     test_ds = TxnDataset(test_df, group_by="User", cat_features=cat_features_loaded, cont_features=cont_features_loaded, window_size=100, stride=50)
     logger.info("Datasets ready in %.2fs", time.perf_counter() - t_ds)
+    print(f"[Main] Datasets ready in {time.perf_counter() - t_ds:.2f}s")
 
     logger.info("Creating DataLoaders")
+    print("[Main] Creating DataLoaders")
     t_dl = time.perf_counter()
     train_loader = DataLoader(train_ds, shuffle=True, batch_size=650, num_workers=4, collate_fn=collate_fn, pin_memory=True)
     val_loader = DataLoader(val_ds, batch_size=650, shuffle=False, num_workers=4, collate_fn=collate_fn, pin_memory=True)
     test_loader = DataLoader(test_ds, batch_size=650, shuffle=False, num_workers=4, collate_fn=collate_fn, pin_memory=True)
     logger.info("DataLoaders ready in %.2fs", time.perf_counter() - t_dl)
+    print(f"[Main] DataLoaders ready in {time.perf_counter() - t_dl:.2f}s")
 
     logger.info("Assembling model configuration")
+    print("[Main] Assembling model configuration")
     EMB_DIM = 48
     ROW_DIM = 256
     field_cfg = FieldTransformerConfig(d_model=EMB_DIM, n_heads=4, depth=1, ffn_mult=2, dropout=0.10, layer_norm_eps=1e-6, norm_first=True)
@@ -74,6 +83,7 @@ def main() -> None:
     )
 
     logger.info("Starting training")
+    print("[Main] Starting training")
     t_train = time.perf_counter()
     train(
         config=config,
@@ -84,6 +94,7 @@ def main() -> None:
         val_loader=val_loader,
     )
     logger.info("Training complete in %.2fs", time.perf_counter() - t_train)
+    print(f"[Main] Training complete in {time.perf_counter() - t_train:.2f}s")
 
 
 if __name__ == "__main__":

--- a/src/txn_model/utils.py
+++ b/src/txn_model/utils.py
@@ -4,6 +4,7 @@ import torch
 from datetime import datetime
 
 def save_checkpoint(model, optimizer, epoch, best_val, path, cat_features, cont_features, config):
+    print(f"[Utils] Saving checkpoint to {path} at epoch {epoch}")
     torch.save({
         "epoch":       epoch,
         "best_val":    best_val,
@@ -47,6 +48,7 @@ def load_or_initialize_checkpoint(
         best_val: Best validation loss (infinite if starting fresh).
         start_epoch: Epoch number to start training from (1-based).
     """
+    print(f"[Utils] Loading checkpoint from {base_path}")
     if os.path.exists(base_path):
         ckpt = torch.load(base_path, map_location=device, weights_only=False)
         old_cat = ckpt.get("cat_features", [])
@@ -85,6 +87,7 @@ def load_or_initialize_checkpoint(
         best_val = float("inf")
         start_epoch = 0
 
+    print(f"[Utils] Checkpoint load result: best_val={best_val}, start_epoch={start_epoch}")
     return best_val, start_epoch
 
 import torch
@@ -103,11 +106,13 @@ def extract_latents_per_card(df_split, model, cat_cols, cont_cols, device):
     Returns:
       X (N×D) latent matrix and y (N,) label vector
     """
+    print("[Utils] Extracting latents per card")
     model.eval()
     X_parts, y_parts = [], []
 
     with torch.no_grad():
         for cc, g in df_split.groupby("cc_num", sort=False):
+            print(f"[Utils] Processing card {cc} with {len(g)} rows")
             # Build tensors of shape (1, L, C) and (1, L, F)
             L = len(g)
             cat_tensor  = torch.tensor(
@@ -147,6 +152,7 @@ def extract_latents_per_card(df_split, model, cat_cols, cont_cols, device):
     # Concatenate all cards
     X = np.vstack(X_parts)                                     # (ΣL, D)
     y = np.concatenate(y_parts)                                # (ΣL,)
+    print(f"[Utils] Extracted latents shape {X.shape}")
     return X, y
 
 


### PR DESCRIPTION
## Summary
- add debug-level logs and prints in dataset, preprocessing, evaluation and training flows
- instrument the model components with print statements
- show progress during AR pretraining
- include logging around checkpoint utilities

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870503e72a4832f9731ea56f6f574c1