### PR TITLE
Optimize dataset loading for pretraining

### DIFF
--- a/scripts/ar_pretrain.py
+++ b/scripts/ar_pretrain.py
@@ -143,7 +143,12 @@ def main(args):
         stride=args.window,
     )
     loader = DataLoader(
-        ds, batch_size=args.batch_size, shuffle=True, collate_fn=collate_fn
+        ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        collate_fn=collate_fn,
+        num_workers=2,
+        pin_memory=True,
     )
 
     print("[AR Pretrain] DataLoader created")

--- a/src/txn_model/ar_pretrain.py
+++ b/src/txn_model/ar_pretrain.py
@@ -141,7 +141,12 @@ def main(args):
         stride=args.window,
     )
     loader = DataLoader(
-        ds, batch_size=args.batch_size, shuffle=True, collate_fn=collate_fn
+        ds,
+        batch_size=args.batch_size,
+        shuffle=True,
+        collate_fn=collate_fn,
+        num_workers=2,
+        pin_memory=True,
     )
 
     optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)

--- a/src/txn_model/data/dataset.py
+++ b/src/txn_model/data/dataset.py
@@ -21,37 +21,47 @@ class TxnDataset(Dataset):
         window_size: int,
         stride: int,
     ) -> None:
-        start = torch.cuda.Event(enable_timing=False)
         logger.info(
             "Initializing TxnDataset with window_size=%s stride=%s", window_size, stride
         )
-        self.samples: List[Dict[str, torch.Tensor]] = []
+
+        self.window_size = window_size
+        self.cat_tensors: List[torch.Tensor] = []
+        self.cont_tensors: List[torch.Tensor] = []
+        self.label_tensors: List[torch.Tensor] = []
+        self.indices: List[tuple[int, int]] = []
+
         for key, group in df.groupby(group_by, sort=False):
             logger.debug("Processing group %s with %d rows", key, len(group))
             cat_tensor = torch.tensor(group[cat_features].values, dtype=torch.long)
             cont_tensor = torch.tensor(group[cont_features].values, dtype=torch.float)
             label_tensor = torch.tensor(group["is_fraud"].values, dtype=torch.long)
+
+            group_idx = len(self.cat_tensors)
+            self.cat_tensors.append(cat_tensor)
+            self.cont_tensors.append(cont_tensor)
+            self.label_tensors.append(label_tensor)
+
             L = cat_tensor.size(0)
             for st in range(0, L - window_size + 1, stride):
-                en = st + window_size
-                self.samples.append(
-                    {
-                        "cat": cat_tensor[st:en],
-                        "cont": cont_tensor[st:en],
-                        "label": label_tensor[en - 1],
-                    }
-                )
-        logger.info("Built %d samples for TxnDataset", len(self.samples))
+                self.indices.append((group_idx, st))
+
+        logger.info("Built %d samples for TxnDataset", len(self.indices))
 
     def __len__(self) -> int:
-        return len(self.samples)
+        return len(self.indices)
 
     def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
         logger.debug("Fetching sample %d", idx)
 
-        # print(f"[Dataset] __getitem__ index {idx}")
+        group_idx, st = self.indices[idx]
+        en = st + self.window_size
 
-        return self.samples[idx]
+        cat_slice = self.cat_tensors[group_idx][st:en]
+        cont_slice = self.cont_tensors[group_idx][st:en]
+        label = self.label_tensors[group_idx][en - 1]
+
+        return {"cat": cat_slice, "cont": cont_slice, "label": label}
 
 
 def collate_fn(batch: List[Dict[str, torch.Tensor]], pad_id: int = 0) -> Dict[str, torch.Tensor]:


### PR DESCRIPTION
## Summary
- rework `TxnDataset` to build indices lazily and reduce memory use
- enable multiple workers and pinned memory in `ar_pretrain.py` scripts

## Testing
- `python -m py_compile src/txn_model/data/dataset.py scripts/ar_pretrain.py src/txn_model/ar_pretrain.py`
