### PR TITLE
Add flexible dataset path config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,9 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignoresrc/txn_model/txn_checkpoint.pt
+# Local dataset directories and config overrides
+/data/
+/datasets/
+txn_data_config.*
+*.feather
+*.pt

--- a/README.md
+++ b/README.md
@@ -13,3 +13,20 @@ to train the backbone in a self-supervised manner. Afterwards fine-tune the
 fraud classifier using `main.py`, which automatically loads
 `pretrained_backbone.pt` when present. Hyperparameters should remain the same
 between the two steps.
+
+## Data Path Configuration
+
+The code expects the raw dataset and intermediate files in a local data
+directory. The location can be configured in one of three ways:
+
+1. **Environment variable:** set `TXN_DATA_DIR` to the directory containing
+   `tabformer.feather`.
+2. **Config file:** create `~/.txn_data_config.json` or
+   `~/.txn_data_config.yaml` with a key `data_dir` pointing to your data
+   directory.
+3. **Default:** if neither of the above is present, the relative `data/`
+   directory under the project root is used.
+
+Paths such as `processed_data.pt` and model checkpoints are stored in this
+directory as well. Keeping the data outside the repository ensures large files
+are not accidentally committed.

--- a/scripts/ar_pretrain.py
+++ b/scripts/ar_pretrain.py
@@ -17,6 +17,7 @@ from txn_model.config import (
 from txn_model.model import TransactionModel
 from txn_model.data.preprocessing import preprocess
 from txn_model.logging_utils import configure_logging
+from txn_model.path_utils import get_data_dir
 
 logger = configure_logging(__name__)
 
@@ -239,7 +240,8 @@ def main(args):
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
-    p.add_argument("--cache", default="processed_data.pt")
+    default_cache = os.path.join(get_data_dir(), "processed_data.pt")
+    p.add_argument("--cache", default=default_cache)
     p.add_argument("--epochs", type=int, default=1)
     p.add_argument("--batch_size", type=int, default=16)
     p.add_argument("--lr", type=float, default=1e-4)

--- a/src/txn_model/ar_pretrain.py
+++ b/src/txn_model/ar_pretrain.py
@@ -17,6 +17,7 @@ from config import (
 from model import TransactionModel
 from data.preprocessing import preprocess
 from logging_utils import configure_logging
+from path_utils import get_data_dir
 
 logger = configure_logging(__name__)
 
@@ -233,9 +234,10 @@ def main(args):
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
+    default_cache = os.path.join(get_data_dir(), "processed_data.pt")
     p.add_argument(
         "--cache",
-        default="/content/drive/MyDrive/summer_urop_25/datasets/processed_data.pt",
+        default=default_cache,
     )
     p.add_argument("--epochs", type=int, default=1)
     p.add_argument("--batch_size", type=int, default=16)

--- a/src/txn_model/main.py
+++ b/src/txn_model/main.py
@@ -5,16 +5,23 @@ from datetime import datetime
 from torch.utils.data import DataLoader
 
 from data.dataset import TxnDataset, collate_fn
-from config import ModelConfig, FieldTransformerConfig, SequenceTransformerConfig, LSTMConfig
+from config import (
+    ModelConfig,
+    FieldTransformerConfig,
+    SequenceTransformerConfig,
+    LSTMConfig,
+)
 from data.preprocessing import preprocess
 from train import train
 from logging_utils import configure_logging
+from path_utils import get_data_dir
 
 logger = configure_logging(__name__)
 
 
-PD_CACHE = "/content/drive/MyDrive/summer_urop_25/datasets/processed_data.pt"
-DATASET_PATH = "/content/drive/MyDrive/summer_urop_25/datasets/tabformer.feather"
+DATA_DIR = get_data_dir()
+PD_CACHE = os.path.join(DATA_DIR, "processed_data.pt")
+DATASET_PATH = os.path.join(DATA_DIR, "tabformer.feather")
 
 cat_features = [
     "User", "Card", "Use Chip", "Merchant Name", "Merchant City",

--- a/src/txn_model/path_utils.py
+++ b/src/txn_model/path_utils.py
@@ -1,0 +1,53 @@
+import json
+import os
+from typing import Optional
+
+try:
+    import yaml
+except Exception:  # If PyYAML isn't installed
+    yaml = None
+
+
+CONFIG_FILES = [
+    os.path.expanduser("~/.txn_data_config.json"),
+    os.path.expanduser("~/.txn_data_config.yaml"),
+    os.path.expanduser("~/.txn_data_config.yml"),
+]
+
+
+def _load_from_file(path: str) -> Optional[str]:
+    """Load the data directory from a JSON/YAML config file."""
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        if path.endswith(".json"):
+            data = json.load(f)
+        else:
+            if yaml is None:
+                raise RuntimeError("PyYAML required for YAML config files")
+            data = yaml.safe_load(f)
+    if isinstance(data, dict):
+        data_dir = data.get("data_dir")
+        if data_dir:
+            return os.path.expanduser(str(data_dir))
+    return None
+
+
+def get_data_dir(default: str = "data") -> str:
+    """Resolve the directory containing dataset files.
+
+    Order of precedence:
+    1. ``TXN_DATA_DIR`` environment variable
+    2. Config file ``~/.txn_data_config.[json|yaml|yml]`` with key ``data_dir``
+    3. Provided ``default`` relative path
+    """
+    env_dir = os.getenv("TXN_DATA_DIR")
+    if env_dir:
+        return os.path.expanduser(env_dir)
+
+    for cfg in CONFIG_FILES:
+        data_dir = _load_from_file(cfg)
+        if data_dir:
+            return data_dir
+
+    return default

--- a/src/txn_model/train.py
+++ b/src/txn_model/train.py
@@ -3,6 +3,8 @@ import time
 import logging
 from datetime import datetime
 
+from path_utils import get_data_dir
+
 import torch
 import torch.nn as nn
 
@@ -42,7 +44,8 @@ def train(
     )
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
 
-    base_path = "/content/drive/MyDrive/summer_urop_25/datasets/txn_checkpoint.pt"
+    data_dir = get_data_dir()
+    base_path = os.path.join(data_dir, "txn_checkpoint.pt")
     best_val, start_epoch = load_or_initialize_checkpoint(
         base_path=base_path,
         device=device,


### PR DESCRIPTION
## Summary
- add `path_utils.get_data_dir` helper
- use helper in training and main modules
- default dataset cache path in ar_pretrain scripts
- document data path configuration
- ignore local dataset directories and override files

